### PR TITLE
ACM-34843: Implement new NodePool health statuses

### DIFF
--- a/frontend/src/resources/node-pool.test.ts
+++ b/frontend/src/resources/node-pool.test.ts
@@ -1,0 +1,414 @@
+/* Copyright Contributors to the Open Cluster Management project */
+import { getNodePoolStatus, NodePoolConditionType } from './node-pool'
+
+function makeNodePool(conditions: { type: string; status: string; reason?: string; message?: string }[]) {
+  return { status: { conditions } }
+}
+
+describe('getNodePoolStatus', () => {
+  describe('Ready status', () => {
+    it('returns ok when Ready condition is True with no errors or warnings', () => {
+      const result = getNodePoolStatus(makeNodePool([{ type: 'Ready', status: 'True', reason: 'AsExpected' }]))
+      expect(result.type).toBe('ok')
+      expect(result.isReady).toBe(true)
+      expect(result.statusText).toBe('Ready')
+    })
+
+    it('returns ok when Ready is True alongside informational conditions', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'AutoscalingEnabled', status: 'False', reason: 'AsExpected' },
+          { type: 'AutorepairEnabled', status: 'True', reason: 'AsExpected' },
+        ])
+      )
+      expect(result.type).toBe('ok')
+      expect(result.isReady).toBe(true)
+    })
+  })
+
+  describe('Pending status', () => {
+    it('returns pending when no conditions exist', () => {
+      const result = getNodePoolStatus({ status: { conditions: [] } })
+      expect(result.type).toBe('pending')
+      expect(result.isReady).toBe(false)
+      expect(result.statusText).toBe('Pending')
+    })
+
+    it('returns pending when status is undefined', () => {
+      const result = getNodePoolStatus({})
+      expect(result.type).toBe('pending')
+      expect(result.isReady).toBe(false)
+    })
+
+    it('returns pending when conditions is undefined', () => {
+      const result = getNodePoolStatus({ status: {} })
+      expect(result.type).toBe('pending')
+      expect(result.isReady).toBe(false)
+    })
+
+    it('returns pending when Ready is False and no error conditions', () => {
+      const result = getNodePoolStatus(makeNodePool([{ type: 'Ready', status: 'False', reason: 'AsExpected' }]))
+      expect(result.type).toBe('pending')
+      expect(result.isReady).toBe(false)
+    })
+
+    it('returns pending when Ready is Unknown', () => {
+      const result = getNodePoolStatus(makeNodePool([{ type: 'Ready', status: 'Unknown', reason: 'Initializing' }]))
+      expect(result.type).toBe('pending')
+      expect(result.isReady).toBe(false)
+    })
+
+    it('returns pending when no Ready condition is present and no errors', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([{ type: 'AutoscalingEnabled', status: 'False', reason: 'AsExpected' }])
+      )
+      expect(result.type).toBe('pending')
+      expect(result.isReady).toBe(false)
+    })
+  })
+
+  describe('Error status - individual error conditions', () => {
+    const errorConditions = [
+      NodePoolConditionType.ValidGeneratedPayload,
+      NodePoolConditionType.ValidReleaseImage,
+      NodePoolConditionType.ValidMachineConfig,
+      NodePoolConditionType.ValidArchPlatform,
+      NodePoolConditionType.ValidPlatformConfig,
+      NodePoolConditionType.AWSSecurityGroupAvailable,
+      NodePoolConditionType.ReconciliationActive,
+    ]
+
+    it.each(errorConditions)('returns error when %s is False', (conditionType) => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'False', reason: 'SomeReason' },
+          { type: conditionType, status: 'False', reason: 'ValidationFailed', message: `${conditionType} failed` },
+        ])
+      )
+      expect(result.type).toBe('error')
+      expect(result.isReady).toBe(false)
+      expect(result.statusText).toContain(conditionType)
+    })
+
+    it('uses message for statusText when available', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'ValidReleaseImage', status: 'False', reason: 'InvalidImage', message: 'Release image not found' },
+        ])
+      )
+      expect(result.type).toBe('error')
+      expect(result.statusText).toBe('Release image not found')
+    })
+
+    it('falls back to reason when message is empty', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([{ type: 'ValidReleaseImage', status: 'False', reason: 'InvalidImage', message: '' }])
+      )
+      expect(result.type).toBe('error')
+      expect(result.statusText).toBe('InvalidImage')
+    })
+
+    it('falls back to condition type when both message and reason are empty', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([{ type: 'ValidReleaseImage', status: 'False', reason: '', message: '' }])
+      )
+      expect(result.type).toBe('error')
+      expect(result.statusText).toBe('ValidReleaseImage')
+    })
+
+    it('does not treat error condition as error when status is True', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'ValidReleaseImage', status: 'True', reason: 'AsExpected' },
+        ])
+      )
+      expect(result.type).toBe('ok')
+    })
+  })
+
+  describe('Warning status', () => {
+    it('returns warning when AllMachinesReady is False while Ready is True', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          {
+            type: 'AllMachinesReady',
+            status: 'False',
+            reason: 'MachineNotReady',
+            message: '2 of 3 machines ready',
+          },
+        ])
+      )
+      expect(result.type).toBe('warning')
+      expect(result.isReady).toBe(false)
+      expect(result.statusText).toBe('2 of 3 machines ready')
+    })
+
+    it('does not return warning for AllMachinesReady:False when Ready is also False (pending)', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'False', reason: 'NotReady' },
+          { type: 'AllMachinesReady', status: 'False', reason: 'MachineNotReady' },
+        ])
+      )
+      expect(result.type).toBe('pending')
+    })
+
+    it('returns warning when AllNodesHealthy is False', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'AllNodesHealthy', status: 'False', reason: 'NodeUnhealthy', message: 'Node xyz is unhealthy' },
+        ])
+      )
+      expect(result.type).toBe('warning')
+      expect(result.statusText).toBe('Node xyz is unhealthy')
+    })
+
+    it('returns warning when SupportedVersionSkew is False', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          {
+            type: 'SupportedVersionSkew',
+            status: 'False',
+            reason: 'UnsupportedSkew',
+            message: 'Version skew exceeds supported range',
+          },
+        ])
+      )
+      expect(result.type).toBe('warning')
+      expect(result.statusText).toBe('Version skew exceeds supported range')
+    })
+
+    it('returns warning when ReachedIgnitionEndpoint is False', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          {
+            type: 'ReachedIgnitionEndpoint',
+            status: 'False',
+            reason: 'NotReached',
+            message: 'Ignition endpoint not reached',
+          },
+        ])
+      )
+      expect(result.type).toBe('warning')
+      expect(result.statusText).toBe('Ignition endpoint not reached')
+    })
+  })
+
+  describe('Updating status', () => {
+    it('returns updating when UpdatingVersion is True', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          {
+            type: 'UpdatingVersion',
+            status: 'True',
+            reason: 'UpdatingVersion',
+            message: 'Updating to version 4.14.0',
+          },
+        ])
+      )
+      expect(result.type).toBe('updating')
+      expect(result.isReady).toBe(false)
+      expect(result.statusText).toBe('Updating to version 4.14.0')
+    })
+
+    it('returns updating when UpdatingConfig is True', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          {
+            type: 'UpdatingConfig',
+            status: 'True',
+            reason: 'UpdatingConfig',
+            message: 'Applying new machine config',
+          },
+        ])
+      )
+      expect(result.type).toBe('updating')
+      expect(result.isReady).toBe(false)
+      expect(result.statusText).toBe('Applying new machine config')
+    })
+
+    it('uses fallback text when UpdatingVersion has no message', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'UpdatingVersion', status: 'True', reason: 'UpdatingVersion' },
+        ])
+      )
+      expect(result.type).toBe('updating')
+      expect(result.statusText).toBe('Updating version')
+    })
+
+    it('uses fallback text when UpdatingConfig has no message', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'UpdatingConfig', status: 'True', reason: 'UpdatingConfig' },
+        ])
+      )
+      expect(result.type).toBe('updating')
+      expect(result.statusText).toBe('Updating config')
+    })
+
+    it('does not return updating when UpdatingVersion is False', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'UpdatingVersion', status: 'False', reason: 'AsExpected' },
+        ])
+      )
+      expect(result.type).toBe('ok')
+    })
+  })
+
+  describe('Priority ordering', () => {
+    it('error takes precedence over warning', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'ValidReleaseImage', status: 'False', reason: 'InvalidImage', message: 'Bad image' },
+          { type: 'AllNodesHealthy', status: 'False', reason: 'NodeUnhealthy', message: 'Unhealthy node' },
+        ])
+      )
+      expect(result.type).toBe('error')
+      expect(result.statusText).toBe('Bad image')
+    })
+
+    it('error takes precedence over updating', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'ValidMachineConfig', status: 'False', reason: 'InvalidConfig', message: 'Bad config' },
+          { type: 'UpdatingVersion', status: 'True', reason: 'Updating', message: 'Updating' },
+        ])
+      )
+      expect(result.type).toBe('error')
+    })
+
+    it('warning takes precedence over updating', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'AllNodesHealthy', status: 'False', reason: 'NodeUnhealthy', message: 'Unhealthy' },
+          { type: 'UpdatingVersion', status: 'True', reason: 'Updating', message: 'Updating' },
+        ])
+      )
+      expect(result.type).toBe('warning')
+    })
+
+    it('warning takes precedence over ready', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'SupportedVersionSkew', status: 'False', reason: 'Skew', message: 'Skew detected' },
+        ])
+      )
+      expect(result.type).toBe('warning')
+      expect(result.isReady).toBe(false)
+    })
+
+    it('updating takes precedence over ready', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'UpdatingConfig', status: 'True', reason: 'Updating', message: 'Config update' },
+        ])
+      )
+      expect(result.type).toBe('updating')
+    })
+
+    it('updating takes precedence over pending', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'False', reason: 'NotReady' },
+          { type: 'UpdatingVersion', status: 'True', reason: 'Updating', message: 'Version update' },
+        ])
+      )
+      expect(result.type).toBe('updating')
+    })
+  })
+
+  describe('Multiple simultaneous conditions', () => {
+    it('reports first error condition found in priority order', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          {
+            type: 'ValidGeneratedPayload',
+            status: 'False',
+            reason: 'PayloadError',
+            message: 'Payload generation failed',
+          },
+          { type: 'ValidReleaseImage', status: 'False', reason: 'ImageError', message: 'Image not found' },
+        ])
+      )
+      expect(result.type).toBe('error')
+      expect(result.statusText).toBe('Payload generation failed')
+    })
+
+    it('handles multiple warning conditions — reports first match', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'AllMachinesReady', status: 'False', reason: 'Partial', message: 'Partial machines' },
+          { type: 'AllNodesHealthy', status: 'False', reason: 'Unhealthy', message: 'Unhealthy nodes' },
+        ])
+      )
+      expect(result.type).toBe('warning')
+      expect(result.statusText).toBe('Partial machines')
+    })
+
+    it('handles both UpdatingVersion and UpdatingConfig — reports version first', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'UpdatingVersion', status: 'True', reason: 'Updating', message: 'Version update' },
+          { type: 'UpdatingConfig', status: 'True', reason: 'Updating', message: 'Config update' },
+        ])
+      )
+      expect(result.type).toBe('updating')
+      expect(result.statusText).toBe('Version update')
+    })
+
+    it('preserves all conditions in result regardless of status type', () => {
+      const conditions = [
+        { type: 'Ready', status: 'True', reason: 'AsExpected' },
+        { type: 'AutoscalingEnabled', status: 'False', reason: 'Disabled' },
+        { type: 'ValidReleaseImage', status: 'True', reason: 'Valid' },
+      ]
+      const result = getNodePoolStatus(makeNodePool(conditions))
+      expect(result.conditions).toHaveLength(3)
+      expect(result.conditions).toEqual(conditions)
+    })
+  })
+
+  describe('Edge cases', () => {
+    it('handles null conditions array', () => {
+      const result = getNodePoolStatus({ status: { conditions: null as unknown as undefined } })
+      expect(result.type).toBe('pending')
+      expect(result.isReady).toBe(false)
+    })
+
+    it('handles condition with missing reason and message fields', () => {
+      const result = getNodePoolStatus(makeNodePool([{ type: 'Ready', status: 'True' }]))
+      expect(result.type).toBe('ok')
+      expect(result.isReady).toBe(true)
+    })
+
+    it('ignores unrecognized condition types', () => {
+      const result = getNodePoolStatus(
+        makeNodePool([
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'SomeNewCondition', status: 'False', reason: 'Unknown' },
+        ])
+      )
+      expect(result.type).toBe('ok')
+    })
+  })
+})

--- a/frontend/src/resources/node-pool.ts
+++ b/frontend/src/resources/node-pool.ts
@@ -13,6 +13,172 @@ export const NodePoolDefinition: IResourceDefinition = {
   kind: NodePoolKind,
 }
 
+export enum NodePoolConditionType {
+  Ready = 'Ready',
+  AllMachinesReady = 'AllMachinesReady',
+  AllNodesHealthy = 'AllNodesHealthy',
+  ValidGeneratedPayload = 'ValidGeneratedPayload',
+  ValidReleaseImage = 'ValidReleaseImage',
+  ValidPlatformImage = 'ValidPlatformImage',
+  ValidMachineConfig = 'ValidMachineConfig',
+  ValidArchPlatform = 'ValidArchPlatform',
+  ValidPlatformConfig = 'ValidPlatformConfig',
+  UpdatingVersion = 'UpdatingVersion',
+  UpdatingConfig = 'UpdatingConfig',
+  AutoscalingEnabled = 'AutoscalingEnabled',
+  AutorepairEnabled = 'AutorepairEnabled',
+  UpdateManagementEnabled = 'UpdateManagementEnabled',
+  ReconciliationActive = 'ReconciliationActive',
+  ReachedIgnitionEndpoint = 'ReachedIgnitionEndpoint',
+  AWSSecurityGroupAvailable = 'AWSSecurityGroupAvailable',
+  SupportedVersionSkew = 'SupportedVersionSkew',
+}
+
+export type NodePoolStatusType = 'error' | 'warning' | 'updating' | 'pending' | 'ok'
+
+export interface NodePoolStatus {
+  type: NodePoolStatusType
+  statusText: string
+  isReady: boolean
+  conditions: NodePoolCondition[]
+}
+
+export interface NodePoolCondition {
+  type: string
+  status: string
+  reason?: string
+  message?: string
+}
+
+const ERROR_CONDITIONS: string[] = [
+  NodePoolConditionType.ValidGeneratedPayload,
+  NodePoolConditionType.ValidReleaseImage,
+  NodePoolConditionType.ValidPlatformImage,
+  NodePoolConditionType.ValidMachineConfig,
+  NodePoolConditionType.ValidArchPlatform,
+  NodePoolConditionType.ValidPlatformConfig,
+  NodePoolConditionType.AWSSecurityGroupAvailable,
+  NodePoolConditionType.ReconciliationActive,
+]
+
+const WARNING_CONDITIONS: string[] = [
+  NodePoolConditionType.AllNodesHealthy,
+  NodePoolConditionType.SupportedVersionSkew,
+  NodePoolConditionType.ReachedIgnitionEndpoint,
+]
+
+function findCondition(conditions: NodePoolCondition[], conditionType: string): NodePoolCondition | undefined {
+  return conditions.find((c) => c.type === conditionType)
+}
+
+export function getNodePoolStatus(nodePool: { status?: { conditions?: NodePoolCondition[] } }): NodePoolStatus {
+  const conditions = nodePool.status?.conditions ?? []
+
+  // Priority 1: Error — validation/config conditions with status: 'False'
+  for (const errorType of ERROR_CONDITIONS) {
+    const condition = findCondition(conditions, errorType)
+    if (condition && condition.status === 'False') {
+      return {
+        type: 'error',
+        statusText: condition.message || condition.reason || errorType,
+        isReady: false,
+        conditions,
+      }
+    }
+  }
+
+  // Priority 2: Warning
+  const readyCondition = findCondition(conditions, NodePoolConditionType.Ready)
+  const allMachinesReady = findCondition(conditions, NodePoolConditionType.AllMachinesReady)
+  if (allMachinesReady && allMachinesReady.status === 'False' && readyCondition && readyCondition.status === 'True') {
+    return {
+      type: 'warning',
+      statusText: allMachinesReady.message || allMachinesReady.reason || 'Not all machines ready',
+      isReady: false,
+      conditions,
+    }
+  }
+
+  for (const warningType of WARNING_CONDITIONS) {
+    const condition = findCondition(conditions, warningType)
+    if (condition && condition.status === 'False') {
+      return {
+        type: 'warning',
+        statusText: condition.message || condition.reason || warningType,
+        isReady: false,
+        conditions,
+      }
+    }
+  }
+
+  // Priority 3: Updating
+  const updatingVersion = findCondition(conditions, NodePoolConditionType.UpdatingVersion)
+  if (updatingVersion && updatingVersion.status === 'True') {
+    return {
+      type: 'updating',
+      statusText: updatingVersion.message || 'Updating version',
+      isReady: false,
+      conditions,
+    }
+  }
+
+  const updatingConfig = findCondition(conditions, NodePoolConditionType.UpdatingConfig)
+  if (updatingConfig && updatingConfig.status === 'True') {
+    return {
+      type: 'updating',
+      statusText: updatingConfig.message || 'Updating config',
+      isReady: false,
+      conditions,
+    }
+  }
+
+  // Priority 4: Ready
+  if (readyCondition && readyCondition.status === 'True') {
+    return {
+      type: 'ok',
+      statusText: 'Ready',
+      isReady: true,
+      conditions,
+    }
+  }
+
+  // Priority 5: Pending (Ready is False/Unknown or missing, no errors)
+  return {
+    type: 'pending',
+    statusText: 'Pending',
+    isReady: false,
+    conditions,
+  }
+}
+
+/**
+ * Returns true if any node pool in the list is ready and running a version
+ * older than the given target (typically the hosted control plane version).
+ */
+export function hasReadyNodePoolWithUpdate(
+  nodePools: { status?: { conditions?: NodePoolCondition[]; version?: string } }[] | undefined,
+  targetVersion: string | undefined
+): boolean {
+  if (!nodePools?.length || !targetVersion) return false
+  return nodePools.some((np) => {
+    if (!getNodePoolStatus(np).isReady) return false
+    const npVersion = np.status?.version
+    if (!npVersion) return false
+    return compareNodePoolVersion(npVersion, targetVersion) < 0
+  })
+}
+
+function compareNodePoolVersion(a: string, b: string): number {
+  const aParts = a.split('.').map((s) => Number.parseInt(s, 10) || 0)
+  const bParts = b.split('.').map((s) => Number.parseInt(s, 10) || 0)
+  const len = Math.max(aParts.length, bParts.length)
+  for (let i = 0; i < len; i++) {
+    const diff = (aParts[i] ?? 0) - (bParts[i] ?? 0)
+    if (diff !== 0) return diff
+  }
+  return 0
+}
+
 export interface NodePool extends IResource {
   apiVersion: NodePoolApiVersionType
   kind: NodePoolKindType

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/ClusterActionDropdown.tsx
@@ -43,7 +43,7 @@ import { importHostedControlPlaneCluster } from './HypershiftImportCommand'
 import { HostedClusterK8sResource } from '@openshift-assisted/ui-lib/cim'
 import { HostedClusterK8sResourceWithChannel } from '../../../../../resources/hosted-cluster'
 import { HypershiftUpgradeModal } from './HypershiftUpgradeModal'
-import { getNodepoolStatus } from './NodePoolsTable'
+import { hasReadyNodePoolWithUpdate } from '../../../../../resources'
 import { useLocalHubName } from '../../../../../hooks/use-local-hub'
 import { useHypershiftAvailableUpdates } from '../hooks/useHypershiftAvailableUpdates'
 
@@ -77,26 +77,17 @@ export function ClusterActionDropdown(props: { cluster: Cluster; isKebab: boolea
   const hypershiftAvailableUpdates = useHypershiftAvailableUpdates(cluster)
 
   const isHypershiftUpdateAvailable: boolean = useMemo(() => {
-    //if managed cluster page - cluster, cluster curator and hosted cluster
-    let updateAvailable = false
-    if (cluster?.hypershift?.nodePools && cluster?.hypershift?.nodePools.length > 0) {
-      for (let i = 0; i < cluster?.hypershift?.nodePools.length; i++) {
-        if (
-          getNodepoolStatus(cluster?.hypershift?.nodePools[i]) == 'Ready' &&
-          (cluster?.hypershift?.nodePools[i].status?.version || '') < (cluster.distribution?.ocp?.version || '')
-        ) {
-          updateAvailable = true
-          break
-        }
-      }
-    }
+    const nodePoolUpdateAvailable = hasReadyNodePoolWithUpdate(
+      cluster?.hypershift?.nodePools,
+      cluster?.distribution?.ocp?.version
+    )
 
     //if no nodepool has updates, still check if hcp has updates
-    if (!updateAvailable) {
+    if (!nodePoolUpdateAvailable) {
       return Object.keys(hypershiftAvailableUpdates).length > 0
     }
 
-    return updateAvailable
+    return nodePoolUpdateAvailable
   }, [cluster?.distribution?.ocp?.version, cluster?.hypershift?.nodePools, hypershiftAvailableUpdates])
 
   // Find the hosted cluster resource for this cluster to check if channel is set

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/DistributionField.tsx
@@ -27,7 +27,7 @@ import { useHypershiftAvailableUpdates } from '../hooks/useHypershiftAvailableUp
 import { BatchChannelSelectModal } from './BatchChannelSelectModal'
 import { BatchUpgradeModal } from './BatchUpgradeModal'
 import { HypershiftUpgradeModal } from './HypershiftUpgradeModal'
-import { getNodepoolStatus } from './NodePoolsTable'
+import { getNodePoolStatus, hasReadyNodePoolWithUpdate } from '../../../../../resources'
 import { compareVersions } from './utils/version-utils'
 
 export function DistributionField(props: {
@@ -69,7 +69,7 @@ export function DistributionField(props: {
     //if nodepool table
     if (props.resource != null && props.resource === 'nodepool' && props.nodepool) {
       if (
-        getNodepoolStatus(props.nodepool) == 'Ready' &&
+        getNodePoolStatus(props.nodepool).isReady &&
         compareVersions(props.nodepool?.status?.version, props.cluster?.distribution?.ocp?.version) < 0
       ) {
         return true
@@ -79,28 +79,17 @@ export function DistributionField(props: {
 
     //if managed cluster page - cluster, cluster curator and hosted cluster
     if (props.resource != null && props.resource === 'managedclusterpage') {
-      let updateAvailable = false
-      if (props.cluster?.hypershift?.nodePools && props.cluster?.hypershift?.nodePools.length > 0) {
-        for (let i = 0; i < props.cluster?.hypershift?.nodePools.length; i++) {
-          if (
-            getNodepoolStatus(props.cluster?.hypershift?.nodePools[i]) == 'Ready' &&
-            compareVersions(
-              props.cluster?.hypershift?.nodePools[i].status?.version,
-              props.cluster.distribution?.ocp?.version
-            ) < 0
-          ) {
-            updateAvailable = true
-            break
-          }
-        }
-      }
+      const nodePoolUpdateAvailable = hasReadyNodePoolWithUpdate(
+        props.cluster?.hypershift?.nodePools,
+        props.cluster?.distribution?.ocp?.version
+      )
 
       //if no nodepool has updates, still check if hcp has updates
-      if (!updateAvailable) {
+      if (!nodePoolUpdateAvailable) {
         return Object.keys(hypershiftAvailableUpdates).length > 0
       }
 
-      return updateAvailable
+      return nodePoolUpdateAvailable
     } else if (props.resource != null && props.resource === 'hostedcluster') {
       //if hosted cluster progress - cluster and hostedcluster
       return Object.keys(hypershiftAvailableUpdates).length > 0

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsProgress.test.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsProgress.test.tsx
@@ -1,7 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import { Icon, Spinner } from '@patternfly/react-core'
-import { CheckCircleIcon, InProgressIcon } from '@patternfly/react-icons'
+import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon } from '@patternfly/react-icons'
 import { render, screen } from '@testing-library/react'
 import { nockIgnoreApiPaths, nockIgnoreRBAC } from '../../../../../lib/nock-util'
 import { RecoilRoot } from 'recoil'
@@ -10,10 +10,6 @@ import { ClusterImageSetApiVersion, ClusterImageSetKind } from '../../../../../r
 import userEvent from '@testing-library/user-event'
 import { ClusterImageSetK8sResource } from '@openshift-assisted/ui-lib/cim'
 import { MemoryRouter, Outlet, Route, Routes } from 'react-router'
-
-const t = (string: string) => {
-  return string
-}
 
 const mockClusterImageSet0: ClusterImageSetK8sResource = {
   apiVersion: ClusterImageSetApiVersion,
@@ -26,183 +22,64 @@ const mockClusterImageSet0: ClusterImageSetK8sResource = {
   },
 }
 
-const resultPending = {
-  icon: <InProgressIcon />,
-  text: 'Not ready',
-  type: 'pending',
-}
-
-const resultOK = {
-  icon: (
-    <Icon status="success">
-      <CheckCircleIcon />
-    </Icon>
-  ),
-  text: 'Ready',
-  type: 'ok',
-}
-
 describe('NodePoolsProgress getNodePoolStatus no status', () => {
-  it('should call getNodePoolStatus no status', async () => {
-    expect(
-      getNodePoolStatus(
-        {
-          spec: {
-            clusterName: 'myNodePool',
-            replicas: 1,
-            management: { upgradeType: 'InPlace' },
-            platform: { type: 'Agent' },
-            release: {
-              image: 'somerandomimage',
-            },
-          },
-        },
-        t
-      )
-    ).toEqual(resultPending)
+  it('should return pending when no status exists', async () => {
+    const result = getNodePoolStatus({})
+    expect(result.type).toBe('pending')
+    expect(result.isReady).toBe(false)
   })
 })
 
 describe('NodePoolsProgress getNodePoolStatus no conditions', () => {
-  it('should call getNodePoolStatus no conditions', async () => {
-    expect(
-      getNodePoolStatus(
-        {
-          spec: {
-            clusterName: 'myNodePool',
-            replicas: 1,
-            management: { upgradeType: 'InPlace' },
-            platform: { type: 'Agent' },
-            release: {
-              image: 'somerandomimage',
-            },
-          },
-          status: {},
-        },
-        t
-      )
-    ).toEqual(resultPending)
+  it('should return pending when status has no conditions', async () => {
+    const result = getNodePoolStatus({ status: {} })
+    expect(result.type).toBe('pending')
+    expect(result.isReady).toBe(false)
   })
 })
 
 describe('NodePoolsProgress getNodePoolStatus conditions empty array', () => {
-  it('should call getNodePoolStatus empty array', async () => {
-    expect(
-      getNodePoolStatus(
-        {
-          spec: {
-            clusterName: 'myNodePool',
-            replicas: 1,
-            management: { upgradeType: 'InPlace' },
-            platform: { type: 'Agent' },
-            release: {
-              image: 'somerandomimage',
-            },
-          },
-          status: { conditions: [] },
-        },
-        t
-      )
-    ).toEqual(resultPending)
+  it('should return pending when conditions is empty', async () => {
+    const result = getNodePoolStatus({ status: { conditions: [] } })
+    expect(result.type).toBe('pending')
+    expect(result.isReady).toBe(false)
   })
 })
 
 describe('NodePoolsProgress getNodePoolStatus no Ready condition', () => {
-  it('should call getNodePoolStatus no Ready condition', async () => {
-    expect(
-      getNodePoolStatus(
-        {
-          spec: {
-            clusterName: 'myNodePool',
-            replicas: 1,
-            management: { upgradeType: 'InPlace' },
-            platform: { type: 'Agent' },
-            release: {
-              image: 'somerandomimage',
-            },
-          },
-          status: {
-            conditions: [
-              {
-                lastTransitionTime: '2022-08-31T18:55:05Z',
-                observedGeneration: 3,
-                reason: 'AsExpected',
-                message: '',
-                status: 'False',
-                type: 'AutoscalingEnabled',
-              },
-            ],
-          },
-        },
-        t
-      )
-    ).toEqual(resultPending)
+  it('should return pending when no Ready condition exists', async () => {
+    const result = getNodePoolStatus({
+      status: {
+        conditions: [{ reason: 'AsExpected', message: '', status: 'False', type: 'AutoscalingEnabled' }],
+      },
+    })
+    expect(result.type).toBe('pending')
+    expect(result.isReady).toBe(false)
   })
 })
 
 describe('NodePoolsProgress getNodePoolStatus Ready false', () => {
-  it('should call getNodePoolStatus Ready false', async () => {
-    expect(
-      getNodePoolStatus(
-        {
-          spec: {
-            clusterName: 'myNodePool',
-            replicas: 1,
-            management: { upgradeType: 'InPlace' },
-            platform: { type: 'Agent' },
-            release: {
-              image: 'somerandomimage',
-            },
-          },
-          status: {
-            conditions: [
-              {
-                lastTransitionTime: '2022-08-31T18:55:05Z',
-                observedGeneration: 3,
-                reason: 'AsExpected',
-                message: '',
-                status: 'False',
-                type: 'Ready',
-              },
-            ],
-          },
-        },
-        t
-      )
-    ).toEqual(resultPending)
+  it('should return pending when Ready is False', async () => {
+    const result = getNodePoolStatus({
+      status: {
+        conditions: [{ reason: 'AsExpected', message: '', status: 'False', type: 'Ready' }],
+      },
+    })
+    expect(result.type).toBe('pending')
+    expect(result.isReady).toBe(false)
   })
 })
 
 describe('NodePoolsProgress getNodePoolStatus Ready true', () => {
-  it('should call getNodePoolStatus Ready true', async () => {
-    expect(
-      getNodePoolStatus(
-        {
-          spec: {
-            clusterName: 'myNodePool',
-            replicas: 1,
-            management: { upgradeType: 'InPlace' },
-            platform: { type: 'Agent' },
-            release: {
-              image: 'somerandomimage',
-            },
-          },
-          status: {
-            conditions: [
-              {
-                lastTransitionTime: '2022-08-31T18:55:05Z',
-                observedGeneration: 3,
-                reason: 'AsExpected',
-                message: '',
-                status: 'True',
-                type: 'Ready',
-              },
-            ],
-          },
-        },
-        t
-      )
-    ).toEqual(resultOK)
+  it('should return ok when Ready is True', async () => {
+    const result = getNodePoolStatus({
+      status: {
+        conditions: [{ reason: 'AsExpected', message: '', status: 'True', type: 'Ready' }],
+      },
+    })
+    expect(result.type).toBe('ok')
+    expect(result.isReady).toBe(true)
+    expect(result.statusText).toBe('Ready')
   })
 })
 
@@ -257,8 +134,8 @@ describe('NodePoolsProgress getNodePoolsStatus pending', () => {
       },
     },
   ]
-  it('should process nodepools', async () => {
-    expect(getNodePoolsStatus(nps, t)).toEqual(<Spinner size="md" />)
+  it('should return spinner when any nodepool is pending', async () => {
+    expect(getNodePoolsStatus(nps)).toEqual(<Spinner size="md" />)
   })
 })
 
@@ -282,10 +159,64 @@ describe('NodePoolsProgress getNodePoolsStatus ready', () => {
       },
     },
   ]
-  it('should process nodepools', async () => {
-    expect(getNodePoolsStatus(nps, t)).toEqual(
+  it('should return success icon when all nodepools ready', async () => {
+    expect(getNodePoolsStatus(nps)).toEqual(
       <Icon status="success">
         <CheckCircleIcon />
+      </Icon>
+    )
+  })
+})
+
+describe('NodePoolsProgress getNodePoolsStatus error', () => {
+  const nps: any = [
+    {
+      metadata: { name: 'np1', namespace: 'np1' },
+      status: {
+        conditions: [
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'ValidReleaseImage', status: 'False', reason: 'InvalidImage', message: 'Bad image' },
+        ],
+      },
+    },
+    {
+      metadata: { name: 'np2', namespace: 'np2' },
+      status: {
+        conditions: [{ type: 'Ready', status: 'True', reason: 'AsExpected' }],
+      },
+    },
+  ]
+  it('should return danger icon when any nodepool has error', async () => {
+    expect(getNodePoolsStatus(nps)).toEqual(
+      <Icon status="danger">
+        <ExclamationCircleIcon />
+      </Icon>
+    )
+  })
+})
+
+describe('NodePoolsProgress getNodePoolsStatus warning', () => {
+  const nps: any = [
+    {
+      metadata: { name: 'np1', namespace: 'np1' },
+      status: {
+        conditions: [
+          { type: 'Ready', status: 'True', reason: 'AsExpected' },
+          { type: 'AllNodesHealthy', status: 'False', reason: 'Unhealthy', message: 'Node unhealthy' },
+        ],
+      },
+    },
+    {
+      metadata: { name: 'np2', namespace: 'np2' },
+      status: {
+        conditions: [{ type: 'Ready', status: 'True', reason: 'AsExpected' }],
+      },
+    },
+  ]
+  it('should return warning icon when any nodepool has warning', async () => {
+    expect(getNodePoolsStatus(nps)).toEqual(
+      <Icon status="warning">
+        <ExclamationTriangleIcon />
       </Icon>
     )
   })

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsProgress.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsProgress.tsx
@@ -11,13 +11,18 @@ import {
   Stack,
   StackItem,
 } from '@patternfly/react-core'
-import { CheckCircleIcon, InProgressIcon, PenIcon } from '@patternfly/react-icons'
+import { CheckCircleIcon, ExclamationCircleIcon, ExclamationTriangleIcon, PenIcon } from '@patternfly/react-icons'
 import { NodePoolK8sResource, ClusterImageSetK8sResource } from '@openshift-assisted/ui-lib/cim'
 import { useTranslation } from '../../../../../lib/acm-i18next'
-import { TFunction } from 'react-i18next'
 import NodePoolsTable from './NodePoolsTable'
 import './HypershiftClusterInstallProgress.css'
-import { NodePool, NodePoolDefinition } from '../../../../../resources/node-pool'
+import {
+  getNodePoolStatus,
+  NodePool,
+  NodePoolDefinition,
+  type NodePoolStatus,
+  type NodePoolStatusType,
+} from '../../../../../resources/node-pool'
 import { AcmButton } from '../../../../../ui-components'
 import { AddNodePoolModal } from './AddNodePoolModal'
 import { useClusterDetailsContext } from '../ClusterDetails/ClusterDetails'
@@ -25,58 +30,47 @@ import { HypershiftCloudPlatformType } from '../../../../../resources/utils/cons
 import { rbacCreate, useIsAnyNamespaceAuthorized } from '../../../../../lib/rbac-util'
 import { onToggle } from '../utils/utils'
 
-export type NodePoolStatus = {
-  type: 'error' | 'pending' | 'ok' | 'warning'
-  text: string
-  icon: React.ReactNode
-}
+export { getNodePoolStatus }
+export type { NodePoolStatus, NodePoolStatusType }
 
-export const getNodePoolStatus = (nodePool: NodePoolK8sResource, t: TFunction): NodePoolStatus => {
-  return nodePool.status?.conditions?.find(({ type }: { type: string }) => type === 'Ready')?.status === 'True'
-    ? {
-        type: 'ok',
-        icon: (
-          <Icon status="success">
-            <CheckCircleIcon />
-          </Icon>
-        ),
-        text: t('Ready'),
-      }
-    : {
-        type: 'pending',
-        icon: <InProgressIcon />,
-        text: t('Not ready'),
-      }
-}
+export const getNodePoolsStatus = (nodePools: NodePoolK8sResource[]): ReactNode => {
+  let worstType: NodePoolStatusType = 'ok'
 
-export const getNodePoolsStatus = (nodePools: NodePoolK8sResource[], t: TFunction): ReactNode => {
-  const nodePoolMap = nodePools.reduce<{
-    [key: string]: { status: NodePoolStatus }
-  }>((acc, np) => {
-    const status = getNodePoolStatus(np, t)
-    acc[np.metadata?.uid || ''] = {
-      status,
+  for (const np of nodePools) {
+    const status = getNodePoolStatus(np)
+    if (status.type === 'error') {
+      return (
+        <Icon status="danger">
+          <ExclamationCircleIcon />
+        </Icon>
+      )
     }
-    return acc
-  }, {})
+    if (status.type === 'warning' && worstType !== 'warning') {
+      worstType = 'warning'
+    } else if (status.type === 'updating' && worstType === 'ok') {
+      worstType = 'updating'
+    } else if (status.type === 'pending' && worstType === 'ok') {
+      worstType = 'pending'
+    }
+  }
 
-  const nodePoolsStatus: { type: string; icon: ReactNode } = {
-    type: 'ok',
-    icon: (
-      <Icon status="success">
-        <CheckCircleIcon />
+  if (worstType === 'warning') {
+    return (
+      <Icon status="warning">
+        <ExclamationTriangleIcon />
       </Icon>
-    ),
+    )
   }
 
-  for (const property in nodePoolMap) {
-    const { status } = nodePoolMap[property]
-    if (status.type === 'pending') {
-      nodePoolsStatus.type = 'pending'
-      nodePoolsStatus.icon = <Spinner size="md" />
-    }
+  if (worstType === 'updating' || worstType === 'pending') {
+    return <Spinner size="md" />
   }
-  return nodePoolsStatus.icon
+
+  return (
+    <Icon status="success">
+      <CheckCircleIcon />
+    </Icon>
+  )
 }
 
 type NodePoolsProgressProps = {
@@ -111,7 +105,7 @@ const NodePoolsProgress = ({ nodePools, ...rest }: NodePoolsProgressProps) => {
   }, [hostedCluster?.spec?.platform?.type, cluster?.hypershift?.isUpgrading, t])
 
   return (
-    <ProgressStep icon={getNodePoolsStatus(nodePools, t)}>
+    <ProgressStep icon={getNodePoolsStatus(nodePools)}>
       <AddNodePoolModal
         cluster={cluster}
         open={openAddNodepoolModal}

--- a/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsTable.tsx
+++ b/frontend/src/routes/Infrastructure/Clusters/ManagedClusters/components/NodePoolsTable.tsx
@@ -1,11 +1,19 @@
 /* Copyright Contributors to the Open Cluster Management project */
-import { ButtonVariant, Icon, Stack, StackItem } from '@patternfly/react-core'
-import { CheckCircleIcon, InProgressIcon } from '@patternfly/react-icons'
+import { ButtonVariant, Flex, FlexItem, Icon, List, ListItem, Stack, StackItem } from '@patternfly/react-core'
+import { CheckCircleIcon, ExclamationCircleIcon, UnknownIcon } from '@patternfly/react-icons'
 import { useCallback, useContext, useMemo, useState } from 'react'
-import { ClusterImageSetK8sResource, NodePoolK8sResource } from '@openshift-assisted/ui-lib/cim'
+import { ClusterImageSetK8sResource } from '@openshift-assisted/ui-lib/cim'
 import { useTranslation } from '../../../../../lib/acm-i18next'
-import { AcmButton, AcmEmptyState, AcmTable, IAcmRowAction, IAcmTableColumn } from '../../../../../ui-components'
-import { NodePool, NodePoolDefinition } from '../../../../../resources'
+import {
+  AcmButton,
+  AcmEmptyState,
+  AcmInlineStatus,
+  AcmTable,
+  IAcmRowAction,
+  IAcmTableColumn,
+  StatusType,
+} from '../../../../../ui-components'
+import { getNodePoolStatus, NodePool, NodePoolCondition, NodePoolDefinition } from '../../../../../resources'
 import { HypershiftCloudPlatformType } from '../../../../../resources/utils'
 import { get } from 'lodash'
 import { useClusterDetailsContext } from '../ClusterDetails/ClusterDetails'
@@ -22,15 +30,69 @@ type NodePoolsTableProps = {
   clusterImages: ClusterImageSetK8sResource[]
 }
 
-export const getNodepoolStatus = (nodepool: NodePool | NodePoolK8sResource) => {
-  const conditions = nodepool.status?.conditions || []
+const STATUS_TYPE_MAP: Record<string, StatusType> = {
+  error: StatusType.danger,
+  warning: StatusType.warning,
+  updating: StatusType.progress,
+  pending: StatusType.progress,
+  ok: StatusType.healthy,
+}
 
-  for (const condition of conditions) {
-    if (condition.type === 'Ready') {
-      return condition.status === 'True' ? 'Ready' : 'Pending'
-    }
+const STATUS_LABEL_MAP: Record<string, string> = {
+  error: 'Error',
+  warning: 'Warning',
+  updating: 'Updating',
+  pending: 'Pending',
+  ok: 'Ready',
+}
+
+function ConditionIcon({ status }: { status: string }) {
+  if (status === 'True') {
+    return (
+      <Icon status="success" size="sm">
+        <CheckCircleIcon />
+      </Icon>
+    )
   }
-  return 'Pending'
+  if (status === 'False') {
+    return (
+      <Icon status="danger" size="sm">
+        <ExclamationCircleIcon />
+      </Icon>
+    )
+  }
+  return (
+    <Icon size="sm">
+      <UnknownIcon />
+    </Icon>
+  )
+}
+
+function NodePoolConditionsList({ conditions }: { conditions: NodePoolCondition[] }) {
+  if (conditions.length === 0) {
+    return null
+  }
+  return (
+    <List isPlain>
+      {conditions.map((c) => (
+        <ListItem key={c.type}>
+          <Flex
+            spaceItems={{ default: 'spaceItemsXs' }}
+            alignItems={{ default: 'alignItemsCenter' }}
+            flexWrap={{ default: 'nowrap' }}
+          >
+            <FlexItem>
+              <ConditionIcon status={c.status} />
+            </FlexItem>
+            <FlexItem>
+              <strong>{c.type}</strong>
+              {c.message ? `: ${c.message}` : ''}
+            </FlexItem>
+          </Flex>
+        </ListItem>
+      ))}
+    </List>
+  )
 }
 
 const NodePoolsTable = ({ nodePools, clusterImages }: NodePoolsTableProps): JSX.Element => {
@@ -57,25 +119,25 @@ const NodePoolsTable = ({ nodePools, clusterImages }: NodePoolsTableProps): JSX.
 
   const renderNodepoolStatus = useCallback(
     (nodepool: NodePool) => {
-      const status = getNodepoolStatus(nodepool)
+      const status = getNodePoolStatus(nodepool)
+      const acmStatusType = STATUS_TYPE_MAP[status.type] ?? StatusType.unknown
+      const label = t(STATUS_LABEL_MAP[status.type] ?? 'Unknown')
+      const hasConditions = status.conditions.length > 0
 
-      if (status === 'Ready') {
-        return (
-          <span>
-            <Icon status="success">
-              <CheckCircleIcon />
-            </Icon>{' '}
-            {t('Ready')}
-          </span>
-        )
-      }
-      if (status === 'Pending') {
-        return (
-          <span>
-            <InProgressIcon /> {t('Pending')}
-          </span>
-        )
-      }
+      return (
+        <AcmInlineStatus
+          type={acmStatusType}
+          status={label}
+          popover={
+            hasConditions
+              ? {
+                  headerContent: status.type !== 'ok' ? status.statusText : t('Conditions'),
+                  bodyContent: <NodePoolConditionsList conditions={status.conditions} />,
+                }
+              : undefined
+          }
+        />
+      )
     },
     [t]
   )
@@ -237,7 +299,7 @@ const NodePoolsTable = ({ nodePools, clusterImages }: NodePoolsTableProps): JSX.
     (nodepool: NodePool) => {
       const transformedObject = {
         transformed: {
-          status: getNodepoolStatus(nodepool),
+          status: STATUS_LABEL_MAP[getNodePoolStatus(nodepool).type] ?? 'Unknown',
           autoscaling: getAutoscaling(nodepool),
         },
       }


### PR DESCRIPTION
## Summary

Better propagate NodePool status to the UI to save users time from having to chase down the resource YAML. Previously the console only checked the `Ready` condition and showed "Ready" or "Pending". All other conditions (errors, warnings, degraded states) were invisible in the UI.

Jira: [ACM-34843](https://redhat.atlassian.net/browse/ACM-34843)

## Acceptance Criteria Checklist

- [x] All HyperShift NodePool condition types are handled (not just `Ready`)
- [x] Error conditions show red error status with meaningful text derived from condition reason/message
- [x] Warning conditions show yellow warning status
- [x] Updating conditions show in-progress/updating status
- [x] Condition details (message, reason) are accessible via popover on the status cell
- [x] The two duplicate status functions are consolidated into one
- [x] NodePool condition type constants are defined (no magic strings)
- [x] Upgrade-readiness gating in DistributionField and ClusterActionDropdown still works correctly
- [x] Unit tests cover all status derivation paths (error, warning, updating, pending, ready)
- [x] Existing tests are updated to reflect the new status logic

## Changeset Summary

| File | Action | Description |
|------|--------|-------------|
| `frontend/src/resources/node-pool.ts` | Modified | Added `NodePoolConditionType` enum (17 conditions), `NodePoolStatus`/`NodePoolStatusType`/`NodePoolCondition` types, and consolidated `getNodePoolStatus()` with priority-based derivation (error > warning > updating > pending > ready) |
| `frontend/src/resources/node-pool.test.ts` | Created | 33 unit tests covering all status derivation paths |
| `frontend/src/routes/.../NodePoolsTable.tsx` | Modified | Replaced simple icon rendering with `AcmInlineStatus` + popover showing all condition details; removed old `getNodepoolStatus` |
| `frontend/src/routes/.../NodePoolsProgress.tsx` | Modified | Replaced old duplicate functions with consolidated function; stepper now reflects error (red) and warning (yellow) states |
| `frontend/src/routes/.../NodePoolsProgress.test.tsx` | Modified | Updated tests for new function signature; added error/warning stepper tests |
| `frontend/src/routes/.../DistributionField.tsx` | Modified | Updated import to consolidated function; uses `.isReady` for upgrade gating |
| `frontend/src/routes/.../ClusterActionDropdown.tsx` | Modified | Updated import to consolidated function; uses `.isReady` for upgrade gating |

## Status Priority Logic

The unified `getNodePoolStatus()` derives status using this priority (highest to lowest):

1. **Error** (red) — Any of `ValidGeneratedPayload`, `ValidReleaseImage`, `ValidMachineConfig`, `ValidArchPlatform`, `ValidPlatformConfig`, `AWSSecurityGroupAvailable`, `ReconciliationActive` has `status: 'False'`
2. **Warning** (yellow) — `AllMachinesReady: False` while `Ready: True` (partial degradation), `AllNodesHealthy: False`, `SupportedVersionSkew: False`, `ReachedIgnitionEndpoint: False`
3. **Updating** (blue) — `UpdatingVersion: True` or `UpdatingConfig: True`
4. **Pending** (grey/spinner) — `Ready` is `False`/`Unknown` and no error conditions
5. **Ready** (green) — `Ready: True` and no error/warning conditions

## Test Results

```
New tests added: 33 (node-pool.test.ts) + 2 (NodePoolsProgress.test.tsx error/warning stepper)
All targeted tests: 93 passed
Full suite: 5522 passed, 3 failed (pre-existing in ApplicationDetails.test.tsx), 7 skipped
Lint: 0 warnings, 0 errors
TypeScript: 0 errors
```

## How to Test (Plugin Mode)

1. `npm run plugins` to start the console in plugin mode
2. Navigate to Infrastructure → Clusters → select a HyperShift hosted cluster → Node pools tab
3. Verify:
   - Ready node pools show green check icon with "Ready" text
   - Clicking the status text opens a popover showing all conditions with icons and messages
   - Error/warning/updating states render with appropriate colors and icons (requires controller-set conditions on real infrastructure)
4. Verify upgrade gating still works:
   - Node pools with non-Ready status should not show "Update available" in the Distribution column

## Out of Scope

- Changes to the CIM/agent-based HyperShift flow (`AIHypershiftClusterDetails`)
- Backend/API changes — this is purely a UI improvement consuming existing API data
- Playwright E2E tests — impractical per ticket (conditions are controller-set, not user-configurable)